### PR TITLE
Systemd service unit support and auto-updater

### DIFF
--- a/link.sh
+++ b/link.sh
@@ -26,15 +26,15 @@ if ! [ "`pwd`" = "$systemwide" ]; then
     echo -n "system-wide location exists; Do you want to remove system-wide version and replace it with that (y/n)?"
     check || { echo "no system-wide, exitting"; exit 3; }
     rm -r "$systemwide"
-    systemctl stop server9x9
-    userdel server9x9
   fi
+  [[ -f /etc/systemd/system/server9x9.service ]] && systemctl stop server9x9
+  id server9x9 &>/dev/null && userdel server9x9
   useradd -r -s /bin/false server9x9
   mkdir "$systemwide"
   cp -r . "$systemwide"
   chown -R server9x9:server9x9 "$systemwide"
   echo "done"
-  rm /etc/sudoers.d/server9x9
+  [[ -f /etc/sudoers.d/server9x9 ]] && rm /etc/sudoers.d/server9x9
   cat << EOT >> /etc/sudoers.d/server9x9
 %server9x9 ALL= NOPASSWD: /bin/systemctl start server9x9
 %server9x9 ALL= NOPASSWD: /bin/systemctl stop server9x9
@@ -48,6 +48,10 @@ fi
 ./unlink.sh
 cp server9x9.service server9x9updater.service server9x9updater.timer  /etc/systemd/system/
 systemctl daemon-reload
-systemctl enable server9x9
-systemctl start server9x9
-systemctl status server9x9
+echo -n "Do you want to enable server9x9 (y/n)?"
+check && systemctl enable server9x9
+echo -n "Do you want to enable auto-updater (y/n)?"
+check && systemctl enable server9x9updater.timer
+echo -n "Do you want to start server9x9 (y/n)?"
+check && { systemctl start server9x9; systemctl status server9x9; }
+echo "DONE, exitting"

--- a/link.sh
+++ b/link.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+check () {
+  echo -n " "
+  old_stty_cfg=$(stty -g)
+  stty raw -echo
+  answer=$( while ! head -c 1 | grep -i '[ny]' ;do true ;done )
+  stty $old_stty_cfg
+  if echo "$answer" | grep -iq "^y"; then
+    echo Yes
+    return 0
+  else
+    echo No
+    return 1
+  fi
+}
+
+systemwide="/usr/local/lib/9x9-server"
+[[ $(id -u) = 0 ]] || { echo "no root, exitting..."; exit 1; }
+cd "$(dirname "$0")"
+if ! [ "`pwd`" = "$systemwide" ]; then
+  echo "no system-wide"
+  echo -n "Do you want to copy the whole current (`pwd`) folder to the system-wide location (y/n)?"
+  check || { echo "no system-wide, exitting..."; exit 2; }
+
+  if [[ -d "$systemwide" ]]; then
+    echo -n "system-wide location exists; Do you want to remove system-wide version and replace it with that (y/n)?"
+    check || { echo "no system-wide, exitting"; exit 3; }
+    rm -r "$systemwide"
+    systemctl stop server9x9
+    userdel server9x9
+  fi
+  useradd -r -s /bin/false server9x9
+  mkdir "$systemwide"
+  cp -r . "$systemwide"
+  chown -R server9x9:server9x9 "$systemwide"
+  echo "done"
+  echo "falling to system-wide link.sh"
+  cd "$systemwide"
+  ./link.sh
+  exit $?
+fi
+./unlink.sh
+cp server9x9.service /etc/systemd/system/server9x9.service
+systemctl daemon-reload
+systemctl enable server9x9
+systemctl start server9x9
+systemctl status server9x9

--- a/link.sh
+++ b/link.sh
@@ -34,13 +34,19 @@ if ! [ "`pwd`" = "$systemwide" ]; then
   cp -r . "$systemwide"
   chown -R server9x9:server9x9 "$systemwide"
   echo "done"
+  rm /etc/sudoers.d/server9x9
+  cat << EOT >> /etc/sudoers.d/server9x9
+%server9x9 ALL= NOPASSWD: /bin/systemctl start server9x9
+%server9x9 ALL= NOPASSWD: /bin/systemctl stop server9x9
+%server9x9 ALL= NOPASSWD: /bin/systemctl status server9x9
+EOT
   echo "falling to system-wide link.sh"
   cd "$systemwide"
   ./link.sh
   exit $?
 fi
 ./unlink.sh
-cp server9x9.service /etc/systemd/system/server9x9.service
+cp server9x9.service server9x9updater.service server9x9updater.timer  /etc/systemd/system/
 systemctl daemon-reload
 systemctl enable server9x9
 systemctl start server9x9

--- a/link.sh
+++ b/link.sh
@@ -50,8 +50,8 @@ cp server9x9.service server9x9updater.service server9x9updater.timer  /etc/syste
 systemctl daemon-reload
 echo -n "Do you want to enable server9x9 (y/n)?"
 check && systemctl enable server9x9
-echo -n "Do you want to enable auto-updater (y/n)?"
-check && systemctl enable server9x9updater.timer
+echo -n "Do you want to enable and start auto-updater (y/n)?"
+check && { systemctl enable server9x9updater.timer; systemctl start server9x9updater.timer; }
 echo -n "Do you want to start server9x9 (y/n)?"
 check && { systemctl start server9x9; systemctl status server9x9; }
 echo "DONE, exitting"

--- a/server9x9.service
+++ b/server9x9.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=9x9 Server Service
+
+[Service]
+User=server9x9
+WorkingDirectory=/usr/local/lib/9x9-server
+Environment=PYTHONUNBUFFERED=1
+
+ExecStart=/usr/bin/env python3 /usr/local/lib/9x9-server/server.py
+SuccessExitStatus=143
+TimeoutStopSec=10
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/server9x9updater.service
+++ b/server9x9updater.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=9x9 Server Updater Service
+
+[Service]
+User=server9x9
+WorkingDirectory=/usr/local/lib/9x9-server
+
+ExecStart=/usr/local/lib/9x9-server/update.sh
+SuccessExitStatus=143
+TimeoutStopSec=10
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/server9x9updater.timer
+++ b/server9x9updater.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run server9x9updater every 15 minutes
+Requires=server9x9updater.service
+
+[Timer]
+Unit=server9x9updater.service
+OnUnitInactiveSec=15m
+
+[Install]
+WantedBy=timers.target

--- a/unlink.sh
+++ b/unlink.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 systemctl stop server9x9
-rm /etc/systemd/system/server9x9.service
+rm /etc/systemd/system/server9x9.service /etc/systemd/system/server9x9updater.service /etc/systemd/system/server9x9updater.timer
 systemctl daemon-reload

--- a/unlink.sh
+++ b/unlink.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+systemctl stop server9x9
+rm /etc/systemd/system/server9x9.service
+systemctl daemon-reload

--- a/unlink.sh
+++ b/unlink.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 [[ $(id -u) = 0 ]] || { echo "no root, exitting..."; exit 1; }
-[[ -f /etc/systemd/system/server9x9updater.timer ]] && rm /etc/systemd/system/server9x9updater.timer
-[[ -f /etc/systemd/system/server9x9updater.service ]] && rm /etc/systemd/system/server9x9updater.service
-[[ -f /etc/systemd/system/server9x9.service ]] && { systemctl stop server9x9; rm /etc/systemd/system/server9x9.service; }
+[[ -f /etc/systemd/system/server9x9updater.timer ]] && { systemctl stop server9x9updater.timer; systemctl disable server9x9updater.timer; rm /etc/systemd/system/server9x9updater.timer; }
+[[ -f /etc/systemd/system/server9x9updater.service ]] && { systemctl stop server9x9updater.service; rm /etc/systemd/system/server9x9updater.service; }
+[[ -f /etc/systemd/system/server9x9.service ]] && { systemctl stop server9x9; systemctl disable server9x9;  rm /etc/systemd/system/server9x9.service; }
 systemctl daemon-reload
+systemctl reset-failed

--- a/unlink.sh
+++ b/unlink.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
-systemctl stop server9x9
-rm /etc/systemd/system/server9x9.service /etc/systemd/system/server9x9updater.service /etc/systemd/system/server9x9updater.timer
+#!/bin/bash
+[[ $(id -u) = 0 ]] || { echo "no root, exitting..."; exit 1; }
+[[ -f /etc/systemd/system/server9x9updater.timer ]] && rm /etc/systemd/system/server9x9updater.timer
+[[ -f /etc/systemd/system/server9x9updater.service ]] && rm /etc/systemd/system/server9x9updater.service
+[[ -f /etc/systemd/system/server9x9.service ]] && { systemctl stop server9x9; rm /etc/systemd/system/server9x9.service; }
 systemctl daemon-reload

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+git fetch
+[[ $(git rev-parse HEAD) == $(git rev-parse @{u}) ]] && { echo "Already up to date, exitting..."; exit 0; }
+sudo systemctl stop server9x9
+sudo systemctl status server9x9
+git pull
+sudo systemctl start server9x9
+sudo systemctl status server9x9

--- a/update.sh
+++ b/update.sh
@@ -3,6 +3,6 @@ git fetch
 [[ $(git rev-parse HEAD) == $(git rev-parse @{u}) ]] && { echo "Already up to date, exitting..."; exit 0; }
 sudo systemctl stop server9x9
 sudo systemctl status server9x9
-git pull
+git pull -f || { git reset "origin/$(git rev-parse --abbrev-ref HEAD)" --hard; git pull; }
 sudo systemctl start server9x9
 sudo systemctl status server9x9


### PR DESCRIPTION
There are `link.sh` and `unlink.sh` installation scripts. The installer copies the whole git repo into `/usr/local/lib/9x9-server` and make there a systemd service unit. Then it adds a timer that checks for updates every 15 minutes and when there is an update, it pulls it from the GitHub and restart the server unit.